### PR TITLE
fix purge_all, purge_by_key and details at Fastly::Service

### DIFF
--- a/lib/fastly/service.rb
+++ b/lib/fastly/service.rb
@@ -59,13 +59,13 @@ class Fastly
 
     # Purge all assets from this service.
     def purge_all
-      res = client.put(get_path(self.id)+"/purge_all")
+      res = fetcher.client.post(Fastly::Service.get_path(self.id)+"/purge_all")
     end
 
 
     # Purge anything with the specific key from the given service.
     def purge_by_key(key)
-       res = client.put(get_path(self.id)+"/purge/#{key}")
+       res = fetcher.client.post(Fastly::Service.get_path(self.id)+"/purge/#{key}")
     end
 
     # Set all the versions that this service has had.
@@ -85,7 +85,7 @@ class Fastly
     
     # A deep hash of nested details
     def details(opts={})
-      client.get(get_path(self.id)+"/details", opts);
+      fetcher.client.get(Fastly::Service.get_path(self.id)+"/details", opts);
     end
     
     # Get the Customer object for this Service


### PR DESCRIPTION
Hi, i just tried to automatically purge Fastly when we deploy the app in to production. But the ruby clients halted with the following error. Could you merge the change and release new version? Thanks -K

``` text
undefined local variable or method `client' for #<Fastly::Service:0x007ff982c11d70>
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/fastly-1.00/lib/fastly/service.rb:62:in `purge_all'
/Users/kzk/repos/td-docs/Rakefile:34:in `block (2 levels) in <top (required)>'
/Users/kzk/repos/td-docs/Rakefile:33:in `each'
/Users/kzk/repos/td-docs/Rakefile:33:in `block in <top (required)>'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block (2 levels) in top_level'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block in top_level'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:88:in `top_level'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
/Users/kzk/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-0.9.2.2/bin/rake:33:in `<top (required)>'
/Users/kzk/.rbenv/versions/2.0.0-p0/bin/rake:23:in `load'
/Users/kzk/.rbenv/versions/2.0.0-p0/bin/rake:23:in `<main>'
Tasks: TOP => purge_cdn
```
