### PR TITLE
Move Fastly::VERSION to dedicated file

### DIFF
--- a/fastly.gemspec
+++ b/fastly.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "fastly"
+require 'fastly/gem_version'
 
 Gem::Specification.new do |s|
   s.name        = "fastly"

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -4,9 +4,7 @@
 
 # A client library for interacting with the Fastly web acceleration service
 class Fastly
-  # The current version of the library
-  VERSION = "1.00"
-
+  require 'fastly/gem_version'
   require 'fastly/fetcher'
   require 'fastly/client'
 

--- a/lib/fastly/gem_version.rb
+++ b/lib/fastly/gem_version.rb
@@ -1,0 +1,4 @@
+class Fastly
+  # The current version of the library
+  VERSION = "1.00"
+end


### PR DESCRIPTION
Removing 'require "fastly"' from gemspec, where it
breaks on bundle install if CurbFu is not already
installed.
