### PR TITLE
README should use 'new_version.activate!', not 'new_version.activate'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Fastly - client library for interacting with the Fastly web acceleration service
     # ... and upload some custom vcl (presuming we have permissions)
     new_version.upload_vcl(vcl_name, File.read(vcl_file))
 
-    new_version.activate
+    new_version.activate!
 
 # Copyright
  


### PR DESCRIPTION
The correct method is `activate!` (presumably because it is destructive) - see [version.rb L81-L83](https://github.com/fastly/fastly-ruby/blob/master/lib/fastly/version.rb#L81-L83)
