### PR TITLE
Loosen the rdoc gem dependency to be compatible with Rails

### DIFF
--- a/fastly.gemspec
+++ b/fastly.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
+
   s.add_dependency 'json'
   s.add_dependency 'curb', '>=0.7.15'
   s.add_dependency 'curb-fu', '>=0.6.1'
-  s.add_dependency 'rdoc', '>=3.11'
+  s.add_dependency 'rdoc', '>=3.4'
 end


### PR DESCRIPTION
Rails uses rdoc 3.4

The fastly-ruby gem uses rdoc >= 3.11

Which means can't update to Rails 3.2.15 because of the gem dependency issue

Bundler could not find compatible versions for gem "rdoc":
  In Gemfile:
    rails (= 3.2.15) ruby depends on
      rdoc (~> 3.4) ruby

```
fastly (~> 1.01) ruby depends on
  rdoc (4.0.1)
```
