### PR TITLE
Adding MIT License

### DIFF
--- a/License
+++ b/License
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2011 Fastly, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -56,12 +56,10 @@ fastly.client.put("/service/#{service.id}/version/#{new_version.number}/vcl/#{vc
 new_version.activate!
 ```
 
-# Copyright
- 
-Copyright 2011 - Fastly Inc
+# License
 
-Mail support at fastly dot com if you have problems.
- 
+[MIT](https://github.com/fastly/fastly-ruby/blob/master/License)
+
 # Developers
 
 http://github.com/fastly/fastly-ruby

--- a/fastly.gemspec
+++ b/fastly.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.name        = "fastly"
   s.version     = Fastly::VERSION
   s.authors     = ["Fastly Inc"]
+  s.license     = "MIT"
   s.email       = ["support@fastly.com"]
   s.homepage    = "http://github.com/fastly/fastly-ruby"
   s.summary     = %q{Client library for the Fastly acceleration system}


### PR DESCRIPTION
If we want people using the gem for real business purposes, we'll need an open source license. Right now, the gem is copyrighted to Fastly, without specific use permissions. So, people currently using the gem aren't legally allowed to do so. Adding this license grants permission, and frees us from liability as people use the gem. See http://choosealicense.com/licenses/mit/ for more info.

This pull request adds the license in a separate file, links to the license through the readme, and adds the license to the gemspec.
