### PR TITLE
S3 logging

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -202,6 +202,10 @@ class Fastly
   # opts must contain service_id, version and name params
   
   ##
+  # :method: create_s3logging(opts)
+  # opts must contain service_id, version and name params
+
+  ##
   # :method: create_syslog(opts)
   # opts must contain service_id, version and name params
 
@@ -252,6 +256,10 @@ class Fastly
   ## 
   # :method: get_origin(service_id, number, name)
   # Get an Origin
+
+  ##
+  # :method: get_s3logging(service_id, number, name)
+  # Get a S3 logging
   
   ## 
   # :method: get_syslog(service_id, number, name)
@@ -323,6 +331,11 @@ class Fastly
   # :method: update_settings(settings)
   # You can also call
   #    settings.save!
+
+  ## 
+  # :method: update_s3logging(s3logging)
+  # You can also call
+  #    s3logging.save!
 
   ## 
   # :method: update_syslog(syslog)
@@ -401,6 +414,11 @@ class Fastly
   #    origin.delete!
 
   ## 
+  # :method: delete_s3logging(s3logging)
+  # You can also call
+  #    s3logging.delete!
+
+  ## 
   # :method: delete_syslog(syslog)
   # You can also call
   #    syslog.delete!
@@ -421,59 +439,59 @@ class Fastly
   # You can also call
   #    version.delete!
 
-  # :method: list_users
+  # :method: list_users(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all users
 
-  # :method: list_customers 
+  # :method: list_customers(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all customers
 
-  # :method: list_versions
+  # :method: list_versions(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all versions
 
-  # :method: list_services 
+  # :method: list_services(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all services
 
-  # :method: list_backends 
+  # :method: list_backends(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all backends
 
-  # :method: list_directors 
+  # :method: list_directors(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all directors
 
-  # :method: list_domains 
+  # :method: list_domains(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all domains
 
-  # :method: list_healthchecks
+  # :method: list_healthchecks(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all healthchecks
 
-  # :method: list_matchs 
+  # :method: list_matchs(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all matches
 
-  # :method: list_origins 
+  # :method: list_origins(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all origins
 
-  # :method: list_syslogs
+  # :method: list_syslogs(:service_id => service.id, :version => version.number)
   # 
   # Get a list of all syslogs
 
-  # :method: list_vcls 
+  # :method: list_vcls(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all vcls
   
-  # :method: list_conditions 
+  # :method: list_conditions(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all conditions
 
-  # :method: list_versions 
+  # :method: list_versions(:service_id => service.id, :version => version.number) 
   # 
   # Get a list of all versions
 

--- a/lib/fastly/s3_logging.rb
+++ b/lib/fastly/s3_logging.rb
@@ -3,6 +3,62 @@ class Fastly
   class S3Logging < BelongsToServiceAndVersion
     attr_accessor :service_id, :name, :bucket_name, :access_key, :secret_key, :path, :period, :gzip_level, :format, :response_condition
 
+        ## 
+        # :attr: service_id
+        # 
+        # The id of the service this belongs to.
+
+        ## 
+        # :attr: version
+        # 
+        # The number of the version this belongs to.
+
+        ## 
+        # :attr: name
+        # 
+        # The name for this s3 rule
+
+	##
+	# :attr: bucket_name
+	#
+	# The name of the s3 bucket
+
+	##
+	# :attr: access_key
+	#
+	# The bucket's s3 account access key
+
+	##
+	# :attr: secret_key
+	#
+	# The bucket's s3 account secret key
+
+	##
+	# :attr: path
+	#
+	# The path to upload logs to
+
+	##
+	# :attr: period
+	#
+	# How frequently the logs should be dumped (in seconds, default 3600)
+
+	##
+	# :attr: gzip_level
+	#
+	# What level of gzip compression to have when dumping the logs (default
+	# 0, no compression).
+
+	##
+	# :attr: format
+	#
+	# Apache style log formatting
+
+	##
+	# :attr: response_condition
+	#
+	# When to execute the s3 logging. If empty, always execute.
+
     private
       # The path here is a bit non-standard
       def self.path


### PR DESCRIPTION
Somewhat separately (but there's more to see), I've added s3 logging to the fastly gem too. However, it does change a little when it's merged with the other branch I've submitted a PR for - until it's merged with that branch, list_s3loggings doesn't work (along with all the other list_\* methods), and after it's merged it changes from get_s3logging, list_s3loggings etc. to get_s3_logging, list_s3_logging, etc.

If it would be easier I can pull this back and resubmit it after such time that other PR gets accepted, but it's different enough I decided to submit two PRs.
