### PR TITLE
Checks for existence of String#underscore prior to overriding

### DIFF
--- a/lib/fastly/string.rb
+++ b/lib/fastly/string.rb
@@ -1,7 +1,9 @@
 # add an underscore method to String, so we can easily convert CamelCase to
 # camel_case for CacheSetting and RequestSetting objects.
 class String
-  def underscore
-    gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase
+  if !instance_methods(false).include?(:underscore)
+    def underscore
+      gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase
+    end
   end
 end


### PR DESCRIPTION
Preventing overriding String#underscore if it already exists, e.g. ActiveSupport's.  There's a lot of functionality that depends on ActiveSupport's underscore implementation within any Rails application, namely ActiveAdmin.    Checking for the existence of the method prior to monkey patching would prevent overriding ActiveSupport's.  

I couldn't for the life of me get the test suite to pass locally prior to making any changes, so I'm not sure if it was already in a broken state or if my test account was incorrectly set-up.
