### PR TITLE
Escape path URI components, so that backends etc with spaces work.

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -122,19 +122,19 @@ class Fastly
             end
 
             def get(path, headers={})
-                CurbFu.get({ :host => host, :port => port, :path => path, :headers => headers, :protocol => protocol })
+                CurbFu.get({ :host => host, :port => port, :path => URI.escape(path), :headers => headers, :protocol => protocol })
             end
 
             def post(path, params, headers={})
-                CurbFu.post({ :host => host, :port => port, :path => path, :headers => headers, :protocol => protocol }, params)
+                CurbFu.post({ :host => host, :port => port, :path => URI.escape(path), :headers => headers, :protocol => protocol }, params)
             end
 
             def put(path, params, headers={})
-                CurbFu.put({ :host => host, :port => port, :path => path, :headers => headers, :params => params, :protocol => protocol }, params)
+                CurbFu.put({ :host => host, :port => port, :path => URI.escape(path), :headers => headers, :params => params, :protocol => protocol }, params)
             end
 
             def delete(path, headers={})
-                CurbFu.delete({ :host => host, :port => port, :path => path, :headers => headers, :protocol => protocol })
+                CurbFu.delete({ :host => host, :port => port, :path => URI.escape(path), :headers => headers, :protocol => protocol })
             end
 
             def use_ssl=(ssl)


### PR DESCRIPTION
URIs with spaces in them are passed un-escaped to Curl, which doesn't do the escaping itself. Add URI.escape calls on the path components (which will contain spaces if, eg, a backend name contains a space.)

Fixes #35.