### PR TITLE
API key takes precedence over user/pass auth

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -92,7 +92,7 @@ class Fastly
         end
 
         def headers
-            headers = fully_authed? ? { 'Cookie' => cookie } : { 'X-Fastly-Key' => api_key }
+            headers = fully_authed? ? { 'Fastly-Key' => api_key } : { 'Cookie' => cookie }
             headers.merge( 'Fastly-Explicit-Customer' => customer ) if customer
             headers.merge( 'Content-Accept' => 'application/json')
         end


### PR DESCRIPTION
Switches the gem to prefer API key based authentication over user/pass cookie based authentication.

@fastly/app @ezkl find @pabergman or I in IRC for more information
