### PR TITLE
Remove the hard gem dependency on Curb

### DIFF
--- a/fastly.gemspec
+++ b/fastly.gemspec
@@ -16,7 +16,4 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-
-  s.add_dependency 'curb', '>=0.7.15'
-  s.add_dependency 'curb-fu', '>=0.6.1'
 end

--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -172,17 +172,19 @@ end
 
 
 
-# :nodoc: all
-class CurbFu::Response::Base
-  def get_fields(key)
-    if ( match = @headers.find{|k,v| k.downcase == key.downcase} )
-      [match.last].flatten
-    else
-      []
+if defined?(CurbFu)
+  # :nodoc: all
+  class CurbFu::Response::Base
+    def get_fields(key)
+      if ( match = @headers.find{|k,v| k.downcase == key.downcase} )
+        [match.last].flatten
+      else
+        []
+      end
     end
-  end
 
-  def [](key)
-    get_fields(key).last
+    def [](key)
+      get_fields(key).last
+    end
   end
 end


### PR DESCRIPTION
Curb sucks. There's no reason to introduce this C-extension dependency to a project unless the end-user really wants it. And if you really want it, it's easy. add `gem 'curb-fu` just before `fastly` in your Gemfile. 