### PR TITLE
Detect if client base_uri is HTTPS

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -15,7 +15,8 @@ class Fastly
 
       base      = opts.fetch(:base_url, 'https://api.fastly.com')
       uri       = URI.parse(base)
-      @http     = Net::HTTP.start(uri.host, uri.port, use_ssl: true)
+      ssl       = uri.is_a? URI::HTTPS  # detect if we should pass `use_ssl`
+      @http     = Net::HTTP.start(uri.host, uri.port, use_ssl: ssl)
 
       return self unless fully_authed?
 


### PR DESCRIPTION
This adds one line so that Net::HTTP is not always started with the `use_ssl: true`.

Since https://github.com/fastly/fastly-ruby/commit/350c3d1ae74b25011aa2998bc140b49d34ef0da4 we've _always_ passed `use_ssl: true` to Net::HTTP in our client init. I ran into a slightly annoying issue while doing some testing where Net::HTTP throws SSL errors if you  provide a HTTP base_uri instead of HTTPS.
