### PR TITLE
Validate was always returning true

### DIFF
--- a/lib/fastly/version.rb
+++ b/lib/fastly/version.rb
@@ -147,7 +147,11 @@ class Fastly
     # Validate this Version
     def validate
       hash = fetcher.client.get("#{Version.put_path(self)}/validate")
-      hash.nil? ? nil : hash
+
+      valid = ("ok" == hash["status"])
+      message = hash['msg']
+
+      [valid, message]
     end
 
     def self.get_path(service, number)

--- a/lib/fastly/version.rb
+++ b/lib/fastly/version.rb
@@ -147,7 +147,7 @@ class Fastly
     # Validate this Version
     def validate
       hash = fetcher.client.get("#{Version.put_path(self)}/validate")
-      !hash.nil?
+      hash.nil? ? nil : hash
     end
 
     def self.get_path(service, number)


### PR DESCRIPTION
Even if VCL was not correct `validate` was always returning true.

This fix will return entire hash with `status` and `msg`.

Before:
```
irb(main):001:0> require 'fastly'
irb(main):002:0> fastly  = Fastly.new({:api_key => 'XYZ'})
irb(main):003:0> service = fastly.get_service('ABC')
irb(main):004:0> service.version.validate
=> true
```
After this fix:
```
irb(main):001:0> require 'fastly'
irb(main):002:0> fastly  = Fastly.new({:api_key => 'XYZ'})
irb(main):003:0> service = fastly.get_service('ABC')
irb(main):004:0> service.version.validate
=> {"status"=>"ok"}
```
or:
```
irb(main):001:0> require 'fastly'
irb(main):002:0> fastly  = Fastly.new({:api_key => 'XYZ'})
irb(main):003:0> service = fastly.get_service('ABC')
irb(main):004:0> service.version.validate
=> {"msg"=>"No VCL named 'test.vcl' known", "status"=>"error"}
```