### PR TITLE
Make Fastly::Client thread safe

### DIFF
--- a/test/thread_safety_test.rb
+++ b/test/thread_safety_test.rb
@@ -1,0 +1,32 @@
+require 'helper'
+
+# Thread Safety Tests
+class Fastly
+  describe 'ApiKeyTest' do
+    let(:opts)             { login_opts(:api_key) }
+    let(:fastly)           { Fastly.new(opts) }
+    let(:service_name)     { "fastly-test-service-#{random_string}" }
+    let(:service)          { fastly.create_service(:name => service_name) }
+
+    before(:each) do
+      assert service
+    end
+
+    after(:each) do
+      service.delete!
+    end
+
+    describe 'get service ids' do
+      it 'does something in parallel' do
+        threads = []
+        20.times do
+          threads << Thread.new do
+            fastly.list_services.find { |fastly| fastly.versions.find { |version| version.service_id == service.id } }.name
+          end
+        end
+
+        threads.map(&:join)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Added synchronization around calls to the underlying `Net::HTTP` object within `Fastly::Client`
* Got rid of `Fastly::Client#require_key?` (not used) and its underlying `require_key` attribute (up for troubles)
* Added the `thread_safety_test.rb` file with a rudimentary test case