### PR TITLE
Remove `Fastly.commands`

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -73,13 +73,6 @@ class Fastly
     @current_user ||= get(User)
   end
 
-  # Return a hash representing all commands available.
-  #
-  # Useful for information.
-  def commands
-    client.get('/commands')
-  end
-
   # Purge the specified path from your cache.
   def purge(path)
     client.post("/purge/#{path}")


### PR DESCRIPTION
[This endpoint][1] is returning a 404 for me regardless of whether I'm authenticated or not.

[1]: https://api.fastly.com/commands