### PR TITLE
require 'openssl'

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'cgi'
 require 'net/http' # also requires uri
+require 'openssl'
 
 class Fastly
   # The UserAgent to communicate with the API


### PR DESCRIPTION
NameError: uninitialized constant Fastly::Client::OpenSSL
	from /Users/thomas/.chefdk/gem/ruby/2.1.0/gems/fastly-1.2.2/lib/fastly/client.rb:21:in `initialize'
	from /Users/thomas/.chefdk/gem/ruby/2.1.0/gems/fastly-1.2.2/lib/fastly/fetcher.rb:19:in `new'
	from /Users/thomas/.chefdk/gem/ruby/2.1.0/gems/fastly-1.2.2/lib/fastly/fetcher.rb:19:in `client'
	from /Users/thomas/.chefdk/gem/ruby/2.1.0/gems/fastly-1.2.2/lib/fastly.rb:48:in `initialize'
	from (irb):3:in `new'
	from (irb):3
	from /opt/chefdk/embedded/bin/irb:11:in `<main>'