### PR TITLE
URL escape names when used in URLs

### DIFF
--- a/lib/fastly/belongs_to_service_and_version.rb
+++ b/lib/fastly/belongs_to_service_and_version.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 class Fastly
   # Encapsulates behavior of objects requiring both service and version
   class BelongsToServiceAndVersion < Base
@@ -23,8 +25,15 @@ class Fastly
       super.delete_if { |var| %w(service_id version).include?(var) }
     end
 
+    # URI escape (including spaces) the path and return it
+    def self.path_escape(path)
+      @uri_parser ||= URI::Parser.new
+      # the leading space in the escape character set is intentional
+      @uri_parser.escape(path, ' !*\'();:@&=+$,/?#[]')
+    end
+
     def self.get_path(service, version, name, _opts = {})
-      "/service/#{service}/version/#{version}/#{path}/#{name}"
+      "/service/#{service}/version/#{version}/#{path}/#{path_escape(name)}"
     end
 
     def self.post_path(opts)


### PR DESCRIPTION
Hello,
I'm not sure if there's a styleguide or something so do let me know if I should change things around.

The API allows names with spaces but GETs and PUTs use the name
unescaped in the URL and the client cannot reference/search for these
resources correctly. The client now escapes the name when it is a
component in the URL, but not when used in request data.