### PR TITLE
Update gem with missing fields

### DIFF
--- a/lib/fastly/backend.rb
+++ b/lib/fastly/backend.rb
@@ -2,7 +2,9 @@ class Fastly
   # An individual host you want to serve assets off
   class Backend < BelongsToServiceAndVersion
     attr_accessor :service_id, :name, :address, :ipv4, :ipv6, :hostname, :use_ssl, :client_cert, :port,
-                  :connect_timeout, :first_byte_timeout, :between_bytes_timeout, :error_threshold, :max_conn, :weight, :comment, :healthcheck, :auto_loadbalance, :request_condition
+                  :connect_timeout, :first_byte_timeout, :between_bytes_timeout, :error_threshold, :max_conn, :weight, :comment, :healthcheck, :auto_loadbalance, :request_condition,
+                  :ssl_check_cert, :ssl_hostname, :ssl_cert_hostname, :ssl_sni_hostname, :min_tls_version, :max_tls_version, :ssl_ciphers,
+                  :shield
 
     ##
     # :attr: service_id
@@ -109,5 +111,46 @@ class Fastly
     # :attr: request_condition
     #
     # name of a request_condition to filter the backend on
+
+    ##
+    # :attr: ssl_check_cert
+    #
+    # be strict on checking SSL certs.
+
+    ##
+    # :attr: ssl_hostname
+    #
+    # used for both SNI during the TLS handshake and to validate the cert.
+
+    ##
+    # :attr: ssl_cert_hostname 
+    #
+    # overrides ssl_hostname, but only for cert verification. Does not affect SNI at all.
+
+    ##
+    # :attr: ssl_sni_hostname 
+    #
+    # overrides ssl_hostname, but only for SNI in the handshake. Does not affect cert validation at all.
+
+    ##
+    # :attr: min_tls_version 
+    #
+    # minimum allowed TLS version on ssl connections to this backend
+
+    ##
+    # :attr: max_tls_version
+    #
+    # maximum allowed TLS version on ssl connections to this backend.
+
+    ##
+    # :attr: ssl_ciphers 
+    #
+    # list of openssl ciphers (see https://www.openssl.org/docs/manmaster/apps/ciphers.html for details)
+
+    ##
+    # :attr: shield
+    #
+    # name of a datacenter to shield requests
+
   end
 end

--- a/lib/fastly/healthcheck.rb
+++ b/lib/fastly/healthcheck.rb
@@ -1,7 +1,7 @@
 class Fastly
   # A way of keeping track of any of your hosts which are down
   class Healthcheck < BelongsToServiceAndVersion
-    attr_accessor :service_id, :name, :comment, :path, :host, :http_version, :timeout, :window, :threshold
+    attr_accessor :service_id, :name, :comment, :path, :host, :http_version, :timeout, :window, :threshold, :method, :expected_response, :initial, :check_interval
 
     ##
     # :attr: service_id
@@ -61,4 +61,24 @@ class Fastly
     #
     # How many have to be ok for it work
   end
+
+    ##
+    # :attr: method
+    #
+    # The HTTP method to use: GET, PUT, POST etc.
+
+    ##
+    # :attr: expected_response
+    #
+    # The HTTP status to indicate a successful healthcheck (e.g. 200)
+
+    ##
+    # :attr: initial
+    #
+    # How many have to be ok for it work the first time
+
+    ##
+    # :attr: check_interval
+    #
+    # Time between checks in milliseconds
 end

--- a/lib/fastly/s3_logging.rb
+++ b/lib/fastly/s3_logging.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An s3 endpoint to stream logs to
   class S3Logging < BelongsToServiceAndVersion
-    attr_accessor :service_id, :name, :bucket_name, :access_key, :secret_key, :path, :period, :gzip_level, :format, :response_condition
+    attr_accessor :service_id, :name, :bucket_name, :access_key, :secret_key, :path, :period, :gzip_level, :format, :response_condition, :timestamp_format
 
     ##
     # :attr: service_id
@@ -58,6 +58,11 @@ class Fastly
     # :attr: response_condition
     #
     # When to execute the s3 logging. If empty, always execute.
+
+    ##
+    # :attr: timestamp_format
+    #
+    # strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000").
 
     def self.path
       'logging/s3'

--- a/lib/fastly/syslog.rb
+++ b/lib/fastly/syslog.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An endpoint to stream syslogs to
   class Syslog < BelongsToServiceAndVersion
-    attr_accessor :service_id, :name, :comment, :ipv4, :ipv6, :hostname, :port, :format, :response_conditions
+    attr_accessor :service_id, :name, :comment, :ipv4, :ipv6, :hostname, :port, :format, :response_conditions, :use_tls, :tls_hostname, :tls_ca_cert 
 
     ##
     # :attr: service_id
@@ -62,5 +62,22 @@ class Fastly
     # :attr: response_condition
     #
     # name of a response_condition to filter the log on, if empty it always logs
+
+    ##
+    # :attr: use_tls
+    #
+    # Establish a TLS connection when connecting
+
+    ##
+    # :attr: tls_hostname
+    #
+    # Hostname used to verify the certificate. It can either be the CN or be in
+    # subAltNames. Not required.
+
+    ##
+    # :attr: tls_ca_cert
+    #
+    # Use this pem formatted certificate as the CA cert to verify the syslog
+    # server's certificate
   end
 end


### PR DESCRIPTION
Hello,
I'm not sure if there's a styleguide or anything so let me know if I should switch things around. Also, `shield` isn't in the API docs but I successfully set it via the API (though I had pulled out the internal values e.g. `amsterdam-nl` for AMS).

backend, healthcheck, s3 and syslog were missing fields that were
settable in the API.