### PR TITLE
Added missing fields to S3Logging and syslog

### DIFF
--- a/lib/fastly/s3_logging.rb
+++ b/lib/fastly/s3_logging.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An s3 endpoint to stream logs to
   class S3Logging < BelongsToServiceAndVersion
-    attr_accessor :service_id, :name, :bucket_name, :access_key, :secret_key, :path, :period, :gzip_level, :format, :response_condition, :timestamp_format
+    attr_accessor :service_id, :name, :bucket_name, :access_key, :secret_key, :path, :period, :gzip_level, :format, :response_condition, :timestamp_format, :domain, :redundancy
 
     ##
     # :attr: service_id
@@ -63,6 +63,21 @@ class Fastly
     # :attr: timestamp_format
     #
     # strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000").
+
+    ##
+    # :attr: domain
+    #
+    # The region-specific endpoint for your domain if your AWS S3 bucket was not
+    # set up in the US Standard region. See Amazon's list of supported,
+    # region-specific endpoints for more info.
+    # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+
+    ##
+    # :attr: redundancy
+    #
+    # The S3 redundancy level. Defaults to Standard. See
+    # http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingRRS.html  on using reduced
+    # redundancy storage for more information.
 
     def self.path
       'logging/s3'

--- a/lib/fastly/syslog.rb
+++ b/lib/fastly/syslog.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An endpoint to stream syslogs to
   class Syslog < BelongsToServiceAndVersion
-    attr_accessor :service_id, :name, :comment, :ipv4, :ipv6, :hostname, :port, :format, :response_conditions, :use_tls, :tls_hostname, :tls_ca_cert 
+    attr_accessor :service_id, :name, :comment, :ipv4, :ipv6, :hostname, :port, :token, :format, :response_conditions, :use_tls, :tls_hostname, :tls_ca_cert
 
     ##
     # :attr: service_id
@@ -52,6 +52,11 @@ class Fastly
     # :attr: port
     #
     # the port to stream logs to (defaults to 514)
+
+    ##
+    # :attr: token
+    #
+    # Whether to prepend each message with a specific token.
 
     ##
     # :attr: format


### PR DESCRIPTION
Hi again,
Here are some more fields. In this case domain and redundancy don't show up in the API docs but they do in the UI. Unfortunately, our config is set to an empty string so that's the extent of testing I've done with these.

Thanks!