### PR TITLE
Update README.md to document exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ curl -H 'Fastly-Key: YOUR_API_KEY' -X POST \
 See the [Fastly purging API documentation](https://docs.fastly.com/api/purge)
 for more information and examples.
 
+Note: If you use an operation that requires authentication, but
+the authention fails (e.g., because someone changed the key),
+many of these methods will raise the AuthRequired exception
+(or one of its children).  You may want to "rescue" the AuthRequired exception
+and log these problems.
+
 ## Usage notes
 
 If you are performing many purges per second we recommend you use the API


### PR DESCRIPTION
The current README.md doesn't mention exceptions that could be raised.  This really needs to be documented.

This lack of documentation hit one of our production sites, when someone did an emergency Fastly API rekey due to public disclosure (but we didn't know about the rekey at first).  It's sensible that authentication failures cause an exception, just TELL people when exceptions can happen.
