### PR TITLE
Reintroduced :locked so the version.locked? check works

### DIFF
--- a/lib/fastly/version.rb
+++ b/lib/fastly/version.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An iteration of your configuration
   class Version < Base
-    attr_accessor :service_id, :number, :name, :active, :staging, :testing, :deployed, :comment
+    attr_accessor :service_id, :number, :name, :active, :staging, :testing, :deployed, :comment, :locked
 
     ##
     # :attr: service_id


### PR DESCRIPTION
Since `:locked` wasn't available, the test of `true == @locked` was failing. It is not failing anymore for me. 

Tested in Ruby 2.2.3p173 based on released Fastly gem 1.4.2.