### PR TITLE
Reintroduced :locked so the version.locked? check works

### DIFF
--- a/lib/fastly/version.rb
+++ b/lib/fastly/version.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An iteration of your configuration
   class Version < Base
-    attr_accessor :service_id, :number, :name, :active, :staging, :testing, :deployed, :comment
+    attr_accessor :service_id, :number, :name, :active, :staging, :testing, :deployed, :comment, :locked
 
     ##
     # :attr: service_id


### PR DESCRIPTION
Adding back `:locked` to `version.rb`, since the logic in `locked?` was failing without it. Tested on my machine in Ruby 2.2.3p173. 

More context in issue #47 