### PR TITLE
Accept username along with user

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -46,9 +46,18 @@ class Fastly
   #
   # Some methods require full username and password rather than just auth token.
   def initialize(opts)
+    if (opts[:api_key].nil?  &&  opts[:password] && opts[:user].nil?)
+      opts[:user] = opts.fetch(:username)
+    end
+    
     client(opts)
     self
   end
+
+   # if opts[:aggregate] && (opts[:field] || opts[:service])
+   #    fail Error, "You can't specify a field or a service for an aggregate request"
+   #  end
+
 
   # Whether or not we're authed at all by either username & password or API key
   def authed?

--- a/test/fastly/client_test.rb
+++ b/test/fastly/client_test.rb
@@ -1,11 +1,12 @@
 require 'test_helper'
 
 describe Fastly::Client do
-  let(:user)        { "test@example.com" }
+  let(:user)          { "test@example.com" }
   let(:password)    { "notasecret" }
   let(:api_key)     { "notasecreteither" }
+  
 
-  describe 'initialize' do
+  describe 'initialize' do    
     it 'raises ArgumentError when no options provided' do
       assert_raises(ArgumentError) {
         Fastly::Client.new()
@@ -45,6 +46,17 @@ describe Fastly::Client do
       client = Fastly::Client.new(user: user, password: pass)
       assert_equal "tasty!", client.cookie
     end
+
+    it 'accepts username in place of user as an option' do
+      stub_request(:any, /api.fastly.com/).
+        to_return(body: JSON.generate(i: "dont care"), status: 200, headers: { 'Set-Cookie' => 'tasty!' })
+
+      fastly = Fastly.new(username: user, password: pass)
+
+      assert_equal fastly.client.user, user
+      assert_equal "tasty!", fastly.client.cookie
+    end
+
   end
 
   describe 'get' do


### PR DESCRIPTION
When "username" is passed in place of "user", initialize method fails with a vague error message. This should allow for "username" and "user" to be used interchangeably. 