### PR TITLE
Raised ArgumentError if api_key or user/pass are not passed in. 

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -46,8 +46,8 @@ class Fastly
   #
   # Some methods require full username and password rather than just auth token.
   def initialize(opts)
-    if (opts[:password] && opts[:user].nil?)
-      opts[:user] || raise(ArgumentError, ':user is required')
+    if opts[:api_key].nil? || (opts[:password] && opts[:user].nil?)
+      raise ArgumentError, "Required options missing. Please pass either key or both user and password."
     end
     
     client(opts)

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -54,11 +54,6 @@ class Fastly
     self
   end
 
-   # if opts[:aggregate] && (opts[:field] || opts[:service])
-   #    fail Error, "You can't specify a field or a service for an aggregate request"
-   #  end
-
-
   # Whether or not we're authed at all by either username & password or API key
   def authed?
     client.authed?

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -46,8 +46,8 @@ class Fastly
   #
   # Some methods require full username and password rather than just auth token.
   def initialize(opts)
-    if (opts[:api_key].nil?  &&  opts[:password] && opts[:user].nil?)
-      opts[:user] = opts.fetch(:username)
+    if (opts[:password] && opts[:user].nil?)
+      opts[:user] || raise(ArgumentError, ':user is required')
     end
     
     client(opts)

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -46,9 +46,18 @@ class Fastly
   #
   # Some methods require full username and password rather than just auth token.
   def initialize(opts)
+    if (opts[:api_key].nil?  &&  opts[:password] && opts[:user].nil?)
+      opts[:user] = opts.fetch(:username)
+    end
+    
     client(opts)
     self
   end
+
+   # if opts[:aggregate] && (opts[:field] || opts[:service])
+   #    fail Error, "You can't specify a field or a service for an aggregate request"
+   #  end
+
 
   # Whether or not we're authed at all by either username & password or API key
   def authed?

--- a/test/fastly/client_test.rb
+++ b/test/fastly/client_test.rb
@@ -52,7 +52,7 @@ describe Fastly::Client do
         fastly = Fastly.new(username: user, password: pass)
       end
     end
-
+    
   end
 
   describe 'get' do

--- a/test/fastly/client_test.rb
+++ b/test/fastly/client_test.rb
@@ -1,11 +1,12 @@
 require 'test_helper'
 
 describe Fastly::Client do
-  let(:user)        { "test@example.com" }
+  let(:user)          { "test@example.com" }
   let(:password)    { "notasecret" }
   let(:api_key)     { "notasecreteither" }
+  
 
-  describe 'initialize' do
+  describe 'initialize' do    
     it 'raises ArgumentError when no options provided' do
       assert_raises(ArgumentError) {
         Fastly::Client.new()
@@ -45,6 +46,17 @@ describe Fastly::Client do
       client = Fastly::Client.new(user: user, password: pass)
       assert_equal "tasty!", client.cookie
     end
+
+    it 'accepts username in place of user as an option' do
+      stub_request(:any, /api.fastly.com/).
+        to_return(body: JSON.generate(i: "dont care"), status: 200, headers: { 'Set-Cookie' => 'tasty!' })
+
+      fastly = Fastly.new(username: user, password: pass)
+
+      assert_equal fastly.client.user, user
+      assert_equal "tasty!", fastly.client.cookie
+    end
+
   end
 
   describe 'get' do

--- a/test/fastly/client_test.rb
+++ b/test/fastly/client_test.rb
@@ -47,14 +47,10 @@ describe Fastly::Client do
       assert_equal "tasty!", client.cookie
     end
 
-    it 'accepts username in place of user as an option' do
-      stub_request(:any, /api.fastly.com/).
-        to_return(body: JSON.generate(i: "dont care"), status: 200, headers: { 'Set-Cookie' => 'tasty!' })
-
-      fastly = Fastly.new(username: user, password: pass)
-
-      assert_equal fastly.client.user, user
-      assert_equal "tasty!", fastly.client.cookie
+    it 'raises an Error if username is used in place of user as an option' do
+      assert_raises(ArgumentError) do
+        fastly = Fastly.new(username: user, password: pass)
+      end
     end
 
   end


### PR DESCRIPTION
Per our earlier discussion with Thom and Josh Lane, the absence of 'user' as an option should raise an error. 