### PR TITLE
sets open timeout (10 secs) on Net:HTTP client to prevent hanging

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -20,14 +20,13 @@ class Fastly
 
       base    = opts.fetch(:base_url, DEFAULT_URL)
       uri     = URI.parse(base)
-      options = if uri.is_a? URI::HTTPS
-                  {
-                    use_ssl: true,
-                    verify_mode: OpenSSL::SSL::VERIFY_PEER
-                  }
-                else
-                  {}
-                end
+      options = {open_timeout: 10}
+      if uri.is_a? URI::HTTPS
+        options.merge!({
+                        use_ssl: true,
+                        verify_mode: OpenSSL::SSL::VERIFY_PEER
+                      })
+      end
 
       @http = Net::HTTP.start(uri.host, uri.port, options)
 


### PR DESCRIPTION
I use the fastly-rails gem to purge by surrogate key, sidekiq manages the queue in the background. Every now and then a purge job is hanging forever.

I managed to solve the issue by setting open timeout on the Net:HTTP client. Hanging connections fail quickly and get rescheduled.

Maybe this behaviour is preferable even if the client is not used in the background. What do you think?

UPDATE
open_timeout is set to 60 secs by default in Ruby v2.3.0 and up. I think 10 secs should be long enough, but 60 would be still better than nil.
