### PR TITLE
add https support to purge function

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -102,6 +102,11 @@ class Fastly
       extras = params.delete(:headers) || {}
       uri    = URI.parse(url)
       http   = Net::HTTP.new(uri.host, uri.port)
+
+      if uri.is_a? URI::HTTPS
+        http.use_ssl = true
+      end
+
       resp   = http.request Net::HTTP::Purge.new(uri.request_uri, headers(extras))
 
       fail Error, resp.body unless resp.kind_of?(Net::HTTPSuccess)


### PR DESCRIPTION
the purge function doesn't seem to work when purging https url's, this patch fixes that problem in a backward compatible way