### PR TITLE
[WIP] Add ACL and ACLEntry to API 

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -9,6 +9,8 @@ require 'fastly/fetcher'
 require 'fastly/client'
 require 'fastly/base'
 require 'fastly/belongs_to_service_and_version'
+require 'fastly/acl'
+require 'fastly/acl_entry'
 require 'fastly/backend'
 require 'fastly/cache_setting'
 require 'fastly/condition'
@@ -142,7 +144,7 @@ class Fastly
     client.get_stats('/stats/regions')
   end
 
-  [User, Customer, Backend, CacheSetting, Condition, Dictionary, DictionaryItem, Director, Domain, Header, Healthcheck, Gzip, Match, RequestSetting, ResponseObject, Service, S3Logging, Syslog, VCL, Version].each do |klass|
+  [ACL, ACLEntry, User, Customer, Backend, CacheSetting, Condition, Dictionary, DictionaryItem, Director, Domain, Header, Healthcheck, Gzip, Match, RequestSetting, ResponseObject, Service, S3Logging, Syslog, VCL, Version].each do |klass|
     type = Util.class_to_path(klass)
 
     if klass.respond_to?(:pluralize)

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -153,6 +153,12 @@ class Fastly
       plural = "#{type}s"
     end
 
+    if klass.respond_to?(:singularize)
+      singular = klass.singularize
+    else
+      singular = type
+    end
+
     # unless the class doesn't have a list path or it already exists
     unless klass.list_path.nil? || klass.respond_to?("list_#{plural}".to_sym)
       send :define_method, "list_#{plural}".to_sym do |*args|
@@ -160,19 +166,19 @@ class Fastly
       end
     end
 
-    send :define_method, "get_#{type}".to_sym do |*args|
+    send :define_method, "get_#{singular}".to_sym do |*args|
       get(klass, *args)
     end
 
-    send :define_method, "create_#{type}".to_sym do |obj|
+    send :define_method, "create_#{singular}".to_sym do |obj|
       create(klass, obj)
     end
 
-    send :define_method, "update_#{type}".to_sym do |obj|
+    send :define_method, "update_#{singular}".to_sym do |obj|
       update(klass, obj)
     end
 
-    send :define_method, "delete_#{type}".to_sym do |obj|
+    send :define_method, "delete_#{singular}".to_sym do |obj|
       delete(klass, obj)
     end
   end

--- a/lib/fastly/acl.rb
+++ b/lib/fastly/acl.rb
@@ -1,0 +1,25 @@
+class Fastly
+  class ACL < BelongsToServiceAndVersion
+    attr_accessor :service_id, :name, :old_name
+
+    ##
+    # :attr: service_id
+    #
+    # The id of the service this belongs to.
+
+    ##
+    # :attr: version
+    #
+    # The number of the version this belongs to.
+
+    ##
+    # :attr: name
+    #
+    # The name of the response object
+
+    ##
+    # :attr: old_name
+    #
+    # The name of the response object to update
+  end
+end

--- a/lib/fastly/acl_entry.rb
+++ b/lib/fastly/acl_entry.rb
@@ -17,6 +17,10 @@ class Fastly
     #
     # The ACL entry id for a specific entry
 
+    def self.singularize
+      'acl_entry'
+    end
+
     def self.pluralize
       'acl_entries'
     end

--- a/lib/fastly/acl_entry.rb
+++ b/lib/fastly/acl_entry.rb
@@ -1,0 +1,24 @@
+class Fastly
+  class ACLEntry < Base
+    attr_accessor :service_id, :acl_id, :entry_id
+
+    ##
+    # :attr: service_id
+    #
+    # The id of the service this belongs to.
+
+    ##
+    # :attr: acl_id
+    #
+    # The ACL id associated to a set of ACL entries
+
+    ##
+    # :attr: entry_id
+    #
+    # The ACL entry id for a specific entry
+
+    def self.pluralize
+      'acl_entries'
+    end
+  end
+end


### PR DESCRIPTION
Add ACL support.

The `ACLEntry` class is a naming edge case. It's currently named according to camel casing standards, but the `class_to_path` won't be able to determine that ACL and Entry are separate words. The other options don't follow the naming standard. `ACL_Entry` for example. This would also require a change to `class_to_path` to remove any repeating underscores such as `acl__entry`. The other option is `AclEntry`, which also doesn't follow the naming pattern.

Hence, I went ahead and added the `singular` class method check similar to `pluralize`.

@schisamo 