### PR TITLE
Add ACL and ACL Entry Support

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -9,6 +9,8 @@ require 'fastly/fetcher'
 require 'fastly/client'
 require 'fastly/base'
 require 'fastly/belongs_to_service_and_version'
+require 'fastly/acl'
+require 'fastly/acl_entry'
 require 'fastly/backend'
 require 'fastly/cache_setting'
 require 'fastly/condition'
@@ -142,13 +144,19 @@ class Fastly
     client.get_stats('/stats/regions')
   end
 
-  [User, Customer, Backend, CacheSetting, Condition, Dictionary, DictionaryItem, Director, Domain, Header, Healthcheck, Gzip, Match, RequestSetting, ResponseObject, Service, S3Logging, Syslog, VCL, Version].each do |klass|
+  [ACL, ACLEntry, User, Customer, Backend, CacheSetting, Condition, Dictionary, DictionaryItem, Director, Domain, Header, Healthcheck, Gzip, Match, RequestSetting, ResponseObject, Service, S3Logging, Syslog, VCL, Version].each do |klass|
     type = Util.class_to_path(klass)
 
     if klass.respond_to?(:pluralize)
       plural = klass.pluralize
     else
       plural = "#{type}s"
+    end
+
+    if klass.respond_to?(:singularize)
+      singular = klass.singularize
+    else
+      singular = type
     end
 
     # unless the class doesn't have a list path or it already exists
@@ -158,19 +166,19 @@ class Fastly
       end
     end
 
-    send :define_method, "get_#{type}".to_sym do |*args|
+    send :define_method, "get_#{singular}".to_sym do |*args|
       get(klass, *args)
     end
 
-    send :define_method, "create_#{type}".to_sym do |obj|
+    send :define_method, "create_#{singular}".to_sym do |obj|
       create(klass, obj)
     end
 
-    send :define_method, "update_#{type}".to_sym do |obj|
+    send :define_method, "update_#{singular}".to_sym do |obj|
       update(klass, obj)
     end
 
-    send :define_method, "delete_#{type}".to_sym do |obj|
+    send :define_method, "delete_#{singular}".to_sym do |obj|
       delete(klass, obj)
     end
   end

--- a/lib/fastly/acl.rb
+++ b/lib/fastly/acl.rb
@@ -1,0 +1,62 @@
+class Fastly
+  # Acces Control List configuration
+  class ACL < BelongsToServiceAndVersion
+    attr_accessor :id, :service_id, :name
+
+    ##
+    # :attr: service_id
+    #
+    # The id of the service this belongs to.
+
+    ##
+    # :attr: version
+    #
+    # The number of the version this belongs to.
+
+    ##
+    # :attr: name
+    #
+    # The name for the ACL.
+
+    ##
+    # List ACL entries that belong to the ACL
+    def list_entries
+      fetcher.list_acl_entries(:service_id => service_id, :acl_id => id)
+    end
+
+    ##
+    # Create an ACL entry and add it to the ACL
+    #
+    def create_entry(opts = {})
+      fetcher.create_acl_entry(
+        service_id: service_id,
+        acl_id: id,
+        ip: opts[:ip],
+        negated: opts[:negated],
+        subnet: opts[:subnet],
+        comment: opts[:comment]
+      )
+    end
+
+    ##
+    # Retrieve an ACL entry
+    #
+    def get_entry(entry_id)
+      fetcher.get_acl_entry(service_id, id, entry_id)
+    end
+
+    ##
+    # Update an ACL entry
+    #
+    def update_entry(entry)
+      fetcher.update_acl_entry(entry)
+    end
+
+    ##
+    # Delete an ACL entry
+    #
+    def delete_entry(entry)
+      fetcher.delete_acl_entry(entry)
+    end
+  end
+end

--- a/lib/fastly/acl_entry.rb
+++ b/lib/fastly/acl_entry.rb
@@ -1,0 +1,61 @@
+require 'cgi'
+
+class Fastly
+  # Acces Control List Entry configuration
+  class ACLEntry < Base
+    attr_accessor :id, :service_id, :ip, :subnet, :acl_id, :negated, :comment
+
+    ##
+    # :attr: ip
+    #
+    # The IP address.
+
+    ##
+    # :attr: subnet
+    #
+    # Optional subnet for the IP address.
+
+    ##
+    # :attr: acl_id
+    #
+    # The ACL this entry belongs to.
+
+    ##
+    # :attr: negated
+    #
+    # A boolean that will negate the match if true.
+
+    ##
+    # :attr: comment
+    #
+    # A descriptive note.
+
+    def self.get_path(service_id, acl_id, id)
+      "/service/#{service_id}/acl/#{acl_id}/entry/#{CGI.escape(id)}"
+    end
+
+    def self.post_path(opts)
+      "/service/#{opts[:service_id]}/acl/#{opts[:acl_id]}/entry"
+    end
+
+    def self.put_path(object)
+      get_path(object.service_id, object.acl_id, object.id)
+    end
+
+    def self.delete_path(object)
+      put_path(object)
+    end
+
+    def self.list_path(opts = {})
+      "/service/#{opts[:service_id]}/acl/#{opts[:acl_id]}/entries"
+    end
+
+    def self.singularize
+      'acl_entry'
+    end
+
+    def self.pluralize
+      'acl_entries'
+    end
+  end
+end

--- a/test/fastly/acl_entry_test.rb
+++ b/test/fastly/acl_entry_test.rb
@@ -1,0 +1,110 @@
+require'test_helper'
+
+describe Fastly::ACLEntry do
+  let(:fastly) { Fastly.new(api_key: 'secret') }
+  let(:service) { fastly.create_service(name: 'acl_service') }
+  let(:acl) { fastly.create_acl(service_id: service.id, version: 1, name: 'acl_group') }
+  let(:acl_entry) { fastly.create_acl_entry(service_id: 'serviceid', acl_id: 'aclid', ip: '1.2.3.5') }
+  let(:response) { nil }
+
+  before do
+    # Must be first
+    stub_request(:any, /api.fastly.com/)
+      .to_return(:status => 200, :body => response)
+
+    # shared Service
+    create_service_response_body = JSON.dump(
+      'id' => 'aclserviceid',
+      'name' => 'acl_service'
+    )
+    stub_request(:post, 'https://api.fastly.com/service')
+      .to_return(:status => 200, :body => create_service_response_body)
+
+    # shared ACL
+    create_acl_response_body = JSON.dump(
+      'id' => 'aclid',
+      'name' => 'acl_group'
+    )
+    stub_request(:post, 'https://api.fastly.com/service/aclserviceid/version/1/acl')
+      .to_return(:status => 200, :body => create_acl_response_body)
+
+    # shared ACLEntry
+    create_acl_entry_response_body = JSON.dump(
+      'id' => 'aclentryid',
+      'acl_id' => 'aclid',
+      'ip' => '1.2.3.5',
+      'service_id' => 'serviceid'
+    )
+
+    stub_request(:post, 'https://api.fastly.com/service/serviceid/acl/aclid/entry')
+      .to_return(:status => 200, :body => create_acl_entry_response_body)
+  end
+
+  describe '#create_entry' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclentryid',
+        'ip' => '1.2.3.5'
+      )
+    end
+
+    it 'creates an ACL entry' do
+      assert_equal acl_entry.ip, '1.2.3.5'
+    end
+  end
+
+  describe '#get_entry' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclentryid',
+        'ip' => '1.2.3.5'
+      )
+    end
+
+    it 'gets an ACL entry' do
+      assert_equal fastly.get_acl_entry('serviceid', 1, 'aclentryid').ip, acl_entry.ip
+    end
+  end
+
+  describe '#update_entry' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclentryid',
+        'ip' => '1.2.3.5',
+        'subnet' => 8
+      )
+    end
+
+    it 'updates an ACL entry' do
+      acl_entry.subnet = 8
+      fastly.update_acl_entry(acl_entry)
+      assert_equal acl_entry.ip, '1.2.3.5'
+      assert_equal acl_entry.subnet, 8
+    end
+  end
+
+  describe '#delete_entry' do
+    let(:response) { '{"status": "ok"}' }
+
+    it 'deletes an ACL entry' do
+      assert_equal fastly.delete_acl_entry(acl_entry), true
+    end
+  end
+
+  describe '#list_entries' do
+    let(:response) do
+      JSON.dump(
+        [
+          {
+            'id' => 'aclentryid',
+            'ip' => '1.2.3.5'
+          }
+        ]
+      )
+    end
+
+    it 'lists ACL entries' do
+      assert_equal fastly.list_acl_entries.first.id, 'aclentryid'
+    end
+  end
+end

--- a/test/fastly/acl_test.rb
+++ b/test/fastly/acl_test.rb
@@ -1,0 +1,163 @@
+require'test_helper'
+
+describe Fastly::ACL do
+  let(:fastly) { Fastly.new(api_key: 'secret') }
+  let(:service) { fastly.create_service(name: 'acl_service') }
+  let(:acl) { fastly.create_acl(service_id: service.id, version: 1, name: 'acl_group') }
+  let(:acl_entry) { acl.create_entry(ip: '1.2.3.5') }
+  let(:response) { nil }
+
+  before do
+    # Must be first
+    stub_request(:any, /api.fastly.com/)
+      .to_return(:status => 200, :body => response)
+
+    # shared Service
+    create_service_response_body = JSON.dump(
+      'id' => 'aclserviceid',
+      'name' => 'acl_service'
+    )
+    stub_request(:post, 'https://api.fastly.com/service')
+      .to_return(:status => 200, :body => create_service_response_body)
+
+    # shared ACL
+    create_acl_response_body = JSON.dump(
+      'id' => 'aclid',
+      'name' => 'acl_group'
+    )
+    stub_request(:post, 'https://api.fastly.com/service/aclserviceid/version/1/acl')
+      .to_return(:status => 200, :body => create_acl_response_body)
+
+    # shared ACLEntry
+    create_acl_entry_response_body = JSON.dump(
+      'id' => 'aclentryid',
+      'ip' => '1.2.3.5'
+    )
+    stub_request(:post, 'https://api.fastly.com/service//acl/aclid/entry')
+      .to_return(:status => 200, :body => create_acl_entry_response_body)
+  end
+
+  it 'creates a new ACL' do
+    assert_equal acl.name, 'acl_group'
+  end
+
+  describe '#get_acl' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclid',
+        'name' => 'acl_group'
+      )
+    end
+
+    it 'gets an ACL' do
+      assert_equal fastly.get_acl(service.id, 1, acl.id).id, 'aclid'
+    end
+  end
+
+  describe '#update_acl' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclid',
+        'name' => 'acl_group_2'
+      )
+    end
+
+    it 'updates an ACL' do
+      acl.name = 'acl_group_2'
+      assert_equal fastly.update_acl(acl).name, 'acl_group_2'
+    end
+  end
+
+  describe '#delete_acl' do
+    let(:response) { '{"status": "ok"}' }
+
+    it 'deletes an ACL' do
+      assert_equal fastly.delete_acl(acl), true
+    end
+  end
+
+  describe '#list_acls' do
+    let(:response) do
+      JSON.dump(
+        [
+          {
+            'id' => 'aclid',
+            'name' => 'acl_group'
+          }
+        ]
+      )
+    end
+
+    it 'lists ACLs' do
+      assert_equal fastly.list_acls.first.id, 'aclid'
+    end
+  end
+
+  describe '#create_entry' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclentryid',
+        'ip' => '1.2.3.5'
+      )
+    end
+
+    it 'creates an ACL entry' do
+      assert_equal acl_entry.ip, '1.2.3.5'
+    end
+  end
+
+  describe '#get_entry' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclentryid',
+        'ip' => '1.2.3.5'
+      )
+    end
+
+    it 'gets an ACL entry' do
+      assert_equal acl.get_entry('aclentryid').ip, acl_entry.ip
+    end
+  end
+
+  describe '#update_entry' do
+    let(:response) do
+      JSON.dump(
+        'id' => 'aclentryid',
+        'ip' => '1.2.3.5',
+        'subnet' => 8
+      )
+    end
+
+    it 'updates an ACL entry' do
+      acl_entry.subnet = 8
+      acl.update_entry(acl_entry)
+      assert_equal acl_entry.ip, '1.2.3.5'
+      assert_equal acl_entry.subnet, 8
+    end
+  end
+
+  describe '#delete_entry' do
+    let(:response) { '{"status": "ok"}' }
+
+    it 'deletes an ACL entry' do
+      assert_equal acl.delete_entry(acl_entry), true
+    end
+  end
+
+  describe '#list_entries' do
+    let(:response) do
+      JSON.dump(
+        [
+          {
+            'id' => 'aclentryid',
+            'ip' => '1.2.3.5'
+          }
+        ]
+      )
+    end
+
+    it 'lists ACL entries' do
+      assert_equal acl.list_entries.first.id, 'aclentryid'
+    end
+  end
+end


### PR DESCRIPTION
ACL and ACLEntry API support
- `singularize` class method
- tests for ACL and managing entries from the ACL instances
- tests for ACL entries (fully instantiated)
- linted the new files

@schisamo @lanej 