### PR TITLE
use public_suffix version 1.4.6 for ruby 1.9

### DIFF
--- a/gemfiles/ruby_1.9.gemfile
+++ b/gemfiles/ruby_1.9.gemfile
@@ -11,6 +11,7 @@ group :development, :test do
   gem "minitest", "~> 5.3.4"
   gem "pry"
   gem "webmock"
+  gem "public_suffix", "~> 1.4.6"
 end
 
 gemspec :path => "../"


### PR DESCRIPTION
This fixes a dependency problem with ruby versions older than 2.0. See https://travis-ci.org/fastly/fastly-ruby/builds/176106718