### PR TITLE
Support Papertrail logging endpoints

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -24,6 +24,7 @@ require 'fastly/healthcheck'
 require 'fastly/gzip'
 require 'fastly/invoice'
 require 'fastly/match'
+require 'fastly/papertrail_logging'
 require 'fastly/request_setting'
 require 'fastly/response_object'
 require 'fastly/service'
@@ -144,7 +145,7 @@ class Fastly
     client.get_stats('/stats/regions')
   end
 
-  [ACL, ACLEntry, User, Customer, Backend, CacheSetting, Condition, Dictionary, DictionaryItem, Director, Domain, Header, Healthcheck, Gzip, Match, RequestSetting, ResponseObject, Service, S3Logging, Syslog, VCL, Version].each do |klass|
+  [ACL, ACLEntry, User, Customer, Backend, CacheSetting, Condition, Dictionary, DictionaryItem, Director, Domain, Header, Healthcheck, Gzip, Match, PapertrailLogging, RequestSetting, ResponseObject, Service, S3Logging, Syslog, VCL, Version].each do |klass|
     type = Util.class_to_path(klass)
 
     if klass.respond_to?(:pluralize)
@@ -216,6 +217,10 @@ class Fastly
 
   ##
   # :method: create_s3_logging(opts)
+  # opts must contain service_id, version and name params
+
+  ##
+  # :method: create_papertrail_logging(opts)
   # opts must contain service_id, version and name params
 
   ##
@@ -297,6 +302,10 @@ class Fastly
   ##
   # :method: get_s3_logging(service_id, number, name)
   # Get a S3 logging
+
+  ##
+  # :method: get_papertrail_logging(service_id, number, name)
+  # Get a Papertrail logging stream config
 
   ##
   # :method: get_syslog(service_id, number, name)
@@ -404,6 +413,11 @@ class Fastly
   #    s3_logging.save!
 
   ##
+  # :method: update_papertrail_logging(papertrail_logging)
+  # You can also call
+  #    papertrail_logging.save!
+
+  ##
   # :method: update_syslog(syslog)
   # You can also call
   #    syslog.save!
@@ -507,6 +521,11 @@ class Fastly
   # :method: delete_s3_logging(s3_logging)
   # You can also call
   #    s3_logging.delete!
+
+  ##
+  # :method: delete_papertrail_logging(papertrail_logging)
+  # You can also call
+  #    papertrail_logging.delete!
 
   ##
   # :method: delete_syslog(syslog)

--- a/lib/fastly/papertrail_logging.rb
+++ b/lib/fastly/papertrail_logging.rb
@@ -1,0 +1,63 @@
+class Fastly
+  # A Papertrail endpoint to stream logs to
+  class PapertrailLogging < BelongsToServiceAndVersion
+    attr_accessor :service_id, :name, :address, :port, :hostname, :format, :format_version, :response_condition, :timestamp_format
+
+    ##
+    # :attr: service_id
+    #
+    # The id of the service this belongs to.
+
+    ##
+    # :attr: version
+    #
+    # The number of the version this belongs to.
+
+    ##
+    # :attr: name
+    #
+    # The name for this s3 rule
+
+    ##
+    # :attr: address
+    #
+    # Hostname of the papertrail server - located at the top of your Papertrail
+    # Setup e.g. https://papertrailapp.com/account/t destinations
+
+    ##
+    # :attr: port
+    #
+    # Port of the Papertrail server from Papertrail account
+
+    ##
+    # :attr: hostname
+    #
+    # Source name of the Fastly logs in Papertrail
+
+    ##
+    # :attr: format
+    #
+    # Apache style log formatting
+
+    ##
+    # :attr: format_version
+    #
+    # The version of the custom logging format used for the configured endpoint.
+    # Can be either 1 (the default, version 1 log format) or 2 (the version 2
+    # log format).
+
+    ##
+    # :attr: response_condition
+    #
+    # When to execute the logging. If empty, always execute.
+
+    ##
+    # :attr: timestamp_format
+    #
+    # strftime specified timestamp formatting (default "%Y-%m-%dT%H:%M:%S.000").
+
+    def self.path
+      'logging/papertrail'
+    end
+  end
+end


### PR DESCRIPTION
Add support for streaming logs to Papertrail, based on the S3Logging class.

Based on the [docs](https://docs.fastly.com/api/logging#logging_papertrail), the Papertrail-specific params are:
```
address	string	An hostname or IPv4 address.
name	string	The name of the papertrail rule.
port	integer	The port number.
```
Not clear in the docs, but required in practice: 

```
hostname	string
```

I basically copy-pasted the S3Logging class, updated the attributes, and copied the `*_s3_logging` methods in fastly.rb. There don't seem to be any specific tests around `S3Logging` so I didn't make any for `PapertrailLogging` either.