### PR TITLE
Allow finding and updating dynamic snippet

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -188,6 +188,16 @@ class Fastly
     end
   end
 
+  # Update a VCL dynamic snippet
+  def update_dynamic_snippet(snippet)
+    update(DynamicSnippet, snippet)
+  end
+
+  # Get a VCL dynamic snippet
+  def get_dynamic_snippet(service_id, snippet_id)
+    get(DynamicSnippet, service_id, snippet_id)
+  end
+
   # :method: create_version(opts)
   # opts must contain a service_id param
 

--- a/lib/fastly/dynamic_snippet.rb
+++ b/lib/fastly/dynamic_snippet.rb
@@ -20,12 +20,12 @@ class Fastly
     # The ID of this dynamic snippet
     #
 
-    def self.get_path(object)
-      "/service/#{object.service_id}/snippet/#{object.snippet_id}"
+    def self.get_path(service_id, snippet_id)
+      "/service/#{service_id}/snippet/#{snippet_id}"
     end
 
     def self.put_path(object)
-      get_path(object)
+      "/service/#{object.service_id}/snippet/#{object.snippet_id}"
     end
   end
 end


### PR DESCRIPTION
Changes DynamicSnippets#get_path, DynamicSnippets#puts_path and add Fastly#update_dynamic_snippet and Fastly#get_dynamic_snippet.

The goal that working with dynamic snippets will be similar syntax to working with regular snippets in terms of find and update.

Currently it's very hard to find existing snippet by id and the only syntax I found to update it is:
```ruby
dyn = Fastly::DynamicSnippet.new({service_id: ..., snippet_id: ..., content: ...}, nil)
fastly.update(DynamicSnippet, dyn)
```
Not very convenient.
If there's better way, please document.