### PR TITLE
Reduce http open_timeout and read_timeout

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -26,6 +26,8 @@ class Fastly
       # handle TLS connections outside of development
       @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       @http.use_ssl = uri.scheme.downcase == 'https'
+      @http.open_timeout = 10 if @http.respond_to?(:open_timeout) # default is 60
+      @http.read_timeout = 10 if @http.respond_to?(:read_timeout) # default is 60
 
       # debug http interactions if specified
       @http.set_debug_output(opts[:debug]) if opts[:debug]


### PR DESCRIPTION
This attempts to fix the IOError: closed stream error referenced in #130, by reducing the http open_timeout and read_timeout from 60 seconds to 10.   Working theory being that Heroku is killing the process because it is taking longer than 30 seconds.  I arbitrarily chose 10 seconds,  but in reality it should probably be much shorter than that.  There is no reason a fastly purge request should take longer than a few hundred milliseconds, let alone 10 seconds.