### PR TITLE
👷➕🐛✅ fix tests in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ group :development, :test do
   gem 'rdoc', '~> 4.1.1'
   gem 'minitest', '~> 5.3.4'
   gem 'pry'
+  gem 'rubocop', '~> 0.57.2', require: false
   gem 'webmock'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -32,14 +32,16 @@ RDoc::Task.new do |rdoc|
   rdoc.rdoc_files.include('README.md', 'lib/**/*.rb')
 end
 
+require 'rake/testtask'
+
 namespace :test do
   desc 'Run all unit tests'
-  task :unit do
-    sh 'bundle exec ruby -Itest -Ilib test/fastly/*_test.rb'
+  Rake::TestTask.new(:unit) do |t|
+    t.libs << 'test'
+    t.test_files = FileList['test/fastly/*_test.rb']
+    t.verbose = true
   end
 end
-
-require 'rake/testtask'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'

--- a/test/fastly/syslog_test.rb
+++ b/test/fastly/syslog_test.rb
@@ -38,7 +38,7 @@ describe Fastly::Syslog do
         'format' => '%h %l %u %t \'%r\' %>s %b',
       )
 
-      get_item_url = "#{Fastly::Client::DEFAULT_URL}/service/#{service_id}/version/#{version}/syslog/#{syslog.name}"
+      get_item_url = "#{Fastly::Client::DEFAULT_URL}/service/#{service_id}/version/#{version}/logging/syslog/#{syslog.name}"
       get_service_url = "#{Fastly::Client::DEFAULT_URL}/service/#{service_id}/version/#{version}"
 
       stub_request(:get, get_service_url).to_return(status: 200, body: '{}', headers: {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 require 'minitest/autorun'
+require 'securerandom'
 require 'webmock/minitest'
 require 'fastly'


### PR DESCRIPTION
 * Gemfile: add rubocop. The Rakefile depended on rubocop test tasks, but we hadn't declared the dependency.
 * syslog test: fix stubbed URL
 * test_helper: require securerandom, which multiple tests use
 * Rakefile: use Rake::TestTask to define `test:unit` task. Previously this task was defined as a shell 
 command but it didn't actually run any of the unit tests.