### PR TITLE
Update Fastly docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,4 +227,4 @@ Mail support at fastly dot com if you have problems.
 ## Developers
 
 * http://github.com/fastly/fastly-ruby
-* http://www.fastly.com/documentation
+* https://docs.fastly.com/api/


### PR DESCRIPTION
Seems right to link directly to API Reference here