### PR TITLE
Remove fully_authed on current_user

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -80,9 +80,7 @@ class Fastly
   end
 
   # Return a User object representing the current logged in user.
-  # NOTE: requires you to be fully authed - will not work with only an API key
   def current_user
-    fail FullAuthRequired unless fully_authed?
     @current_user ||= get(User)
   end
 


### PR DESCRIPTION
Removed the code below in order to be able access the method by api_key
fail FullAuthRequired unless fully_authed?