### PR TITLE
install bundler before using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
-script: 'bundle exec rake test:unit'
+before_script:
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+script:
+  - bundle exec rake test:unit
 sudo: false
 matrix:
   include:


### PR DESCRIPTION
not sure when this changed but for ruby 2.1.10, the bundler executable
is not available so let's install it