### PR TITLE
Add support for acl entries mass update

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -173,6 +173,14 @@ class Fastly
       end
     end
 
+    # unless the class doesn't have a patch path or it already exists
+    unless klass.patch_path.nil? || klass.respond_to?("update_#{plural}".to_sym)
+      send :define_method, "update_#{plural}".to_sym do |opts|
+        patch(klass, opts)
+      end
+    end
+
+
     send :define_method, "get_#{singular}".to_sym do |*args|
       get(klass, *args)
     end

--- a/lib/fastly/acl.rb
+++ b/lib/fastly/acl.rb
@@ -58,5 +58,20 @@ class Fastly
     def delete_entry(entry)
       fetcher.delete_acl_entry(entry)
     end
+
+    ##
+    # Mass update ACL entries
+    #
+    def update_entries(entries)
+      opts = {
+        service_id: service_id,
+        acl_id: id,
+        params: {
+          entries: entries
+        }
+      }
+
+      fetcher.update_acl_entries(opts)
+    end
   end
 end

--- a/lib/fastly/acl_entry.rb
+++ b/lib/fastly/acl_entry.rb
@@ -46,6 +46,10 @@ class Fastly
       put_path(object)
     end
 
+    def self.patch_path(opts = {})
+      "/service/#{opts[:service_id]}/acl/#{opts[:acl_id]}/entries"
+    end
+
     def self.list_path(opts = {})
       "/service/#{opts[:service_id]}/acl/#{opts[:acl_id]}/entries"
     end

--- a/lib/fastly/base.rb
+++ b/lib/fastly/base.rb
@@ -53,6 +53,10 @@ class Fastly
       post_path(opts)
     end
 
+    def self.patch_path(opts = {})
+      post_path(opts)
+    end
+
     def self.put_path(object)
       get_path(object.id)
     end

--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'json'
 require 'cgi'
 require 'net/http' # also requires uri
@@ -77,11 +76,15 @@ class Fastly
     end
 
     def post(path, params = {})
-      post_and_put(:post, path, params)
+      http_request(:post, path, params)
     end
 
     def put(path, params = {})
-      post_and_put(:put, path, params)
+      http_request(:put, path, params)
+    end
+
+    def patch(path, params = {})
+      http_request(:patch, path, params)
     end
 
     def delete(path, params = {})
@@ -130,7 +133,7 @@ class Fastly
       net_http
     end
 
-    def post_and_put(method, path, params = {})
+    def http_request(method, path, params = {})
       extras = params.delete(:headers) || {}
       query = make_params(params)
       resp  = http.send(method, path, query, headers(extras).merge('Content-Type' =>  'application/x-www-form-urlencoded'))

--- a/lib/fastly/fetcher.rb
+++ b/lib/fastly/fetcher.rb
@@ -47,5 +47,9 @@ class Fastly
     def delete(klass, obj)
       client.delete(klass.delete_path(obj))
     end
+
+    def patch(klass, opts)
+      client.patch(klass.patch_path(opts), opts)
+    end
   end
 end

--- a/test/fastly/acl_test.rb
+++ b/test/fastly/acl_test.rb
@@ -35,6 +35,13 @@ describe Fastly::ACL do
     )
     stub_request(:post, 'https://api.fastly.com/service//acl/aclid/entry')
       .to_return(:status => 200, :body => create_acl_entry_response_body)
+
+    stub_request(:patch, 'https://api.fastly.com/service/aclserviceid/acl/aclid/entries')
+      .to_return(
+        status: 200,
+        body: '{ "status": "ok" }',
+        headers: {}
+      )
   end
 
   it 'creates a new ACL' do
@@ -158,6 +165,14 @@ describe Fastly::ACL do
 
     it 'lists ACL entries' do
       assert_equal acl.list_entries.first.id, 'aclentryid'
+    end
+  end
+
+  describe '#update_entries' do
+    it 'update ACL entries' do
+      acl.service_id = service.id
+      entries = []
+      assert_equal acl.update_entries(entries), { "status" => 'ok' }
     end
   end
 end

--- a/test/fastly/client_test.rb
+++ b/test/fastly/client_test.rb
@@ -100,6 +100,33 @@ describe Fastly::Client do
     end
   end
 
+  describe 'patch' do
+    let(:client) { Fastly::Client.new(api_key: api_key) }
+
+    it 'raises Fastly::Error on unsuccessful PATCH' do
+      stub_request(:any, /api.fastly.com/).to_return(status: 400)
+
+      assert_raises(Fastly::Error) {
+        client.patch('/service/blah', {})
+      }
+    end
+
+    it 'can make a successful PATCH' do
+      stub_request(:any, /api.fastly.com/).
+        to_return(body: JSON.generate(i: "dont care"), status: 200)
+
+      resp = client.patch('/service/blah', { data: [1,2,3] })
+      assert_equal resp.class, Hash
+      assert_includes resp, "i"
+
+      assert_requested(
+        :patch,
+        /api.fastly.com\/service\/blah/,
+        body: "data=%5B1%2C+2%2C+3%5D"
+      )
+    end
+  end
+
   describe 'get_stats' do
     let(:client) { Fastly::Client.new(api_key: api_key) }
 


### PR DESCRIPTION
Add support for ACL entry mass edit endpoint : https://docs.fastly.com/api/config#acl_entry_c352ca5aee49b7898535cce488e3ba82

```ruby
fastly = Fastly.new({api_key: 'your-key'})
acl = fastly.get_acl(service_id, version_number, acl_name)

entries = [
  "entries": [
    {
      "op": "create",
      "ip": "192.168.0.1",
      "subnet": "8"
    },
    {
      "op": "delete",
      "id": "acl_entry_id"
    }
  ]
]

acl.update_entries(entries)
# => {"status"=>"ok"}
```