### PR TITLE
Fix build error by using pattern match for User-Agent string

### DIFF
--- a/lib/fastly/gem_version.rb
+++ b/lib/fastly/gem_version.rb
@@ -1,4 +1,4 @@
 # The current version of the library
 class Fastly
-  VERSION = "2.5.0"
+  VERSION = "2.5.1"
 end

--- a/test/fastly/client_test.rb
+++ b/test/fastly/client_test.rb
@@ -107,7 +107,7 @@ describe Fastly::Client do
           'Content-Accept'=>'application/json',
           'Content-Type'=>'application/x-www-form-urlencoded',
           #'Fastly-Key'=>'notasecreteither',
-          'User-Agent'=>'fastly-ruby-v2.4.0'
+          'User-Agent'=> /fastly-ruby/
           }).
         to_return(body: JSON.generate(i: "dont care"), status: 200)
 

--- a/test/fastly/token_test.rb
+++ b/test/fastly/token_test.rb
@@ -21,7 +21,7 @@ describe Fastly::Token do
         'Content-Accept'=>'application/json',
         'Content-Type'=>'application/x-www-form-urlencoded',
         'Cookie'=>'tasty!',
-        'User-Agent'=>'fastly-ruby-v2.4.0'
+        'User-Agent'=> /fastly-ruby/
         }).
       to_return(status: 403, body: '{"msg":"You must POST /sudo to access this endpoint"}', headers: {})
 
@@ -59,7 +59,7 @@ describe Fastly::Token do
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
         'Content-Accept'=>'application/json',
         'Content-Type'=>'application/x-www-form-urlencoded',
-        'User-Agent'=>'fastly-ruby-v2.4.0'
+        'User-Agent'=> /fastly-ruby/
         }).
       to_return(status: 200, body: response_body, headers: {})
 
@@ -89,7 +89,7 @@ describe Fastly::Token do
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
         'Content-Accept'=>'application/json',
         'Fastly-Key'=>'my_api_key',
-        'User-Agent'=>'fastly-ruby-v2.4.0'
+        'User-Agent'=> /fastly-ruby/
         }).
       to_return(status: 204, body: "", headers: {})
 
@@ -105,7 +105,7 @@ describe Fastly::Token do
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Accept'=>'application/json',
           'Fastly-Key'=>'my_api_key',
-          'User-Agent'=>'fastly-ruby-v2.4.0'
+          'User-Agent'=> /fastly-ruby/
           }).
         to_return(status: 200, body: "[]", headers: {})
 
@@ -120,7 +120,7 @@ describe Fastly::Token do
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Accept'=>'application/json',
           'Fastly-Key'=>'my_api_key',
-          'User-Agent'=>'fastly-ruby-v2.4.0'
+          'User-Agent'=> /fastly-ruby/
           }).
         to_return(status: 200, body: "[]", headers: {})
 


### PR DESCRIPTION
### What did I do?
Unit tests were failing because the gem version was bumped and the response `User-Agent` string contains the gem version. Use a pattern match for the `User-Agent` string so we don't have to change these tests each time we release a new gem.

### Feels gif
![](https://media.giphy.com/media/6A8PRrChk5u2k/giphy.gif)

