### PR TITLE
Fix new_token() and remove session auth from client

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -18,31 +18,10 @@ class Fastly
       @base_url           = opts.fetch(:base_url, DEFAULT_URL)
       @customer           = opts.fetch(:customer, nil)
       @oldpurge           = opts.fetch(:use_old_purge_method, false)
-      @password           = opts.fetch(:password, nil)
-      @user               = opts.fetch(:user, nil)
       @debug              = opts.fetch(:debug, nil)
       @thread_http_client = if defined?(Concurrent::ThreadLocalVar)
                               Concurrent::ThreadLocalVar.new { build_http_client }
                             end
-
-      return self unless fully_authed?
-
-      warn("DEPRECATION WARNING: Username/password authentication is deprecated
-      and will not be available starting September 2020;
-      please migrate to API tokens as soon as possible.")
-
-      # If full auth creds (user/pass) then log in and set a cookie
-      resp = http.post(
-        '/login', 
-        make_params(user: user, password: password), 
-        {'Content-Type' =>  'application/x-www-form-urlencoded'}
-      )
-      if resp.kind_of?(Net::HTTPSuccess)
-        @cookie = resp['Set-Cookie']
-      else
-        fail Unauthorized, "Invalid auth credentials. Check username/password."
-      end
-
       self
     end
 
@@ -56,12 +35,7 @@ class Fastly
     end
 
     def authed?
-      !api_key.nil? || fully_authed?
-    end
-
-    # Some methods require full username and password rather than just auth token
-    def fully_authed?
-      !(user.nil? || password.nil?)
+      !api_key.nil?
     end
 
     def get(path, params = {})
@@ -150,9 +124,8 @@ class Fastly
 
     def headers(extras={}, include_auth=true)
       headers = {}
-      # Some endpoints (POST /tokens) break if any auth headers including cookies are sent
+      # Some endpoints (POST /tokens) break if the Fastly-key header is sent
       if include_auth
-        headers['Cookie'] = cookie if fully_authed?
         headers['Fastly-Key'] = api_key if api_key
       end
       headers.merge('Content-Accept' => 'application/json', 'User-Agent' => "fastly-ruby-v#{Fastly::VERSION}").merge(extras.keep_if {|k,v| !v.nil? })

--- a/lib/fastly/token.rb
+++ b/lib/fastly/token.rb
@@ -21,10 +21,7 @@ class Fastly
   end
 
   def new_token(opts)
-    opts[:username] = client.user
-    opts[:password] = client.password
     opts[:include_auth] = false
-    
     token = create(Token, opts)
     token.nil? ? nil : token
   end


### PR DESCRIPTION
The important change is to remove the lines
```
    opts[:username] = client.user
    opts[:password] = client.password
```
from `token.rb::new_token()` because client never needs nor wants to know username and password now that session auth is deprecated.

We may as well remove all the session references from client as they can no longer have any effect.

Note that new_token needs to be called like this, for example
```
          token = client.new_token(
            name: @name,
            services: @use_version.service_id,
            scope: 'purge_all purge_select',
            username: username,
            password: password,
          )
```
Which is as expected given the docs example: https://developer.fastly.com/reference/api/auth/#create-token