### PR TITLE
[fix] Remove deprecation warning about username and password

### DIFF
--- a/lib/fastly/client.rb
+++ b/lib/fastly/client.rb
@@ -24,10 +24,6 @@ class Fastly
       @thread_http_client = if defined?(Concurrent::ThreadLocalVar)
                               Concurrent::ThreadLocalVar.new { build_http_client }
                             end
-
-      warn("DEPRECATION WARNING: Username/password authentication is deprecated
-      and will not be available starting September 2020;
-      please migrate to API tokens as soon as possible.")
       
       if api_key.nil?
         fail Unauthorized, "Invalid auth credentials. Check api_key."


### PR DESCRIPTION
Remove deprecation warning about Username and password signing in in the client

**What**
Now that the code pretaining to Authing in with Username and Password is removed, the deprecation warning in the client is not needed. To avoid further confusion, the warning is removed.