### PR TITLE
CI to automatically publish to RubyGems

### DIFF
--- a/.github/scripts/pack.sh
+++ b/.github/scripts/pack.sh
@@ -1,0 +1,17 @@
+# install deps
+bundle install
+
+# tag the version
+sed -i "s/^  VERSION = .*$/  VERSION = '${VERSION}'/" lib/fastly/version.rb
+bundle install
+
+# make a gem (output is always ./pkg)
+rake build
+
+# save the output filename to env
+PACKAGE_FILENAME=$(cd ./pkg && ls -1 -- *.gem)
+echo "PACKAGE_FILENAME=${PACKAGE_FILENAME}" >> "${GITHUB_ENV}"
+
+# move gem to dist
+mkdir "${GITHUB_WORKSPACE}/dist"
+mv "./pkg/${PACKAGE_FILENAME}" "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}"

--- a/.github/scripts/pack.sh
+++ b/.github/scripts/pack.sh
@@ -1,11 +1,11 @@
 # install deps
 bundle install
 
-# tag the version
+# mark version
 sed -i "s/^  VERSION = .*$/  VERSION = '${VERSION}'/" lib/fastly/version.rb
 bundle install
 
-# make a gem (output is always ./pkg)
+# make a gem (output is ./pkg)
 rake build
 
 # save the output filename to env
@@ -13,5 +13,5 @@ PACKAGE_FILENAME=$(cd ./pkg && ls -1 -- *.gem)
 echo "PACKAGE_FILENAME=${PACKAGE_FILENAME}" >> "${GITHUB_ENV}"
 
 # move gem to dist
-mkdir "${GITHUB_WORKSPACE}/dist"
+mkdir -p "${GITHUB_WORKSPACE}/dist"
 mv "./pkg/${PACKAGE_FILENAME}" "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}"

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,0 +1,11 @@
+echo "Publishing ${PROJECT_NAME} to ${PACKAGE_REPO_NAME}"
+echo " Publishing version: ${VERSION}"
+echo " Publish tag is ${PUBLISH_TAG}"
+
+# perform publish
+if [ "${DRY_RUN}" == "1" ]; then
+  echo "(dry run)"
+else
+  rake build
+  gem push ./pkg/"${PACKAGE_FILENAME}"
+fi

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,0 +1,35 @@
+# Parse the release tag
+
+# strip leading 'release/'
+TAG="${GITHUB_REF_NAME#release/}"
+
+# strip leading v
+TAG_VALUE="${TAG#v}"
+
+# strip trailing -dry
+VERSION="${TAG_VALUE%-dry}"
+
+# detect valid semver
+VALID_VERSION=$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field matches)
+if [ "${VALID_VERSION}" != "true" ]; then
+  exit 1
+fi
+
+# Detect dry run mode
+DRY_RUN=0
+if [ "${TAG_VALUE}" != "${VERSION}" ]; then
+    DRY_RUN=1
+fi
+
+# publish tag ('alpha', 'beta', etc.) is used to tag the release
+PUBLISH_TAG="$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field preid)"
+if [ "${PUBLISH_TAG}" == "undefined" ]; then
+  PUBLISH_TAG=latest
+fi
+
+echo "API_CLIENT_NAME=Ruby"
+echo "PROJECT_NAME=fastly-ruby"
+echo "PACKAGE_REPO_NAME=RubyGems"
+echo "VERSION=${VERSION}"
+echo "DRY_RUN=${DRY_RUN}"
+echo "PUBLISH_TAG=${PUBLISH_TAG}"

--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,0 +1,25 @@
+printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION}"
+
+if [ "${DRY_RUN}" == "1" ]; then
+  printf '%s' " (dry run)"
+fi
+
+echo ""
+
+# add a newline
+echo ""
+
+CODE_PATH=${CODE_PATH:-./}
+G_CODE=$(jq -r .G "${CODE_PATH}/sig.json")
+D_CODE=$(jq -r .D "${CODE_PATH}/sig.json")
+
+PACKAGE_FILESIZE=$(ls -lh "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}" | awk '{print $5}')B
+
+echo "Artifact"
+echo " ${PACKAGE_FILENAME} (${PACKAGE_FILESIZE})"
+echo ""
+echo "Generated on: $(date)"
+echo "G-code: ${G_CODE}, D-code: ${D_CODE}"
+if [ "${PUBLISH_TAG}" != "latest" ]; then
+  echo "Pre-release Tag: ${PUBLISH_TAG}"
+fi

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,0 +1,59 @@
+name: Release CI
+on:
+  push:
+    tags:
+      # This looks like a regex, but it's actually a filter pattern
+      # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - 'release/v?[0-9]*'
+
+env:
+  GITHUB_REF_NAME: ${{ github.ref_name }}
+
+jobs:
+  publish:
+    name: Publish to RubyGems
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Set up environment variables
+        run: ./.github/scripts/publish_env.sh >> $GITHUB_ENV
+        working-directory: ./main
+        shell: bash
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Pack API client
+        run: ./.github/scripts/pack.sh
+        working-directory: ./main
+        shell: bash
+      - name: Auth with RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_PUBLISH_TOKEN }}" > ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+        shell: bash
+      - name: Publish API client
+        run: ./.github/scripts/publish.sh
+        working-directory: ./main
+        shell: bash
+      - name: Write release body file
+        run: CODE_PATH=./main ./main/.github/scripts/release_body.sh > ./dist/release_body.txt
+        shell: bash
+      - name: Create release (dry run)
+        if: ${{ env.DRY_RUN == '1' }}
+        run: cat ./dist/release_body.txt
+      - name: Create GitHub release
+        if: ${{ env.DRY_RUN != '1' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.VERSION }}
+          body_path: ./dist/release_body.txt
+          files: |
+            ./dist/${{ env.PACKAGE_FILENAME }}
+          draft: false
+          prerelease: ${{ env.PUBLISH_TAG != 'latest' }}


### PR DESCRIPTION
This PR adds a publish mechanism to allow this API client to publish itself to RubyGems and create a release in GitHub.

The input is to create a tag in this repo and push it, with the syntax: `release/[VERSION][-dry]`.

- `VERSION` should be the version number that the package should be published under, such as `v3.0.1` or `3.0.1-alpha.0` (leading `v` is optional and ignored)
- Specify `-dry` if you want to do a "dry run" which doesn't actually publish to RubyGems or create a release

This CI is intended to be used along with the client generator project, whose job it is to generate the newest API client code, tag it with said version code, and push it to this repo.

Unless running in `-dry` mode, this CI step will create a real version in RubyGems, and a release in GitHub. Example run using `release/v4.0.1-alpha.0` has generated the following:
 - CI run: https://github.com/fastly/fastly-ruby/actions/runs/3683591087
 - RubyGems release: https://rubygems.org/gems/fastly/versions/4.0.1.pre.alpha.0
 - GitHub release: https://github.com/fastly/fastly-ruby/releases/tag/release%2Fv4.0.1-alpha.0
 - Artifact (rubygem): https://github.com/fastly/fastly-ruby/releases/download/release%2Fv4.0.1-alpha.0/fastly-4.0.1.pre.alpha.0.gem
   - Note the artifact is added to the GitHub release as a release asset

If running in `-dry` mode, no actual RubyGems publish or release will be made. Example run using `release/v4.0.1-alpha.0-dry`:
 - CI run: https://github.com/fastly/fastly-ruby/actions/runs/3683579613
   - Click through this link into the "Publish to RubyGems" job, and read the output of the "Create Release (Dry Run)" step. You'll see the following output:
      ```
      ## Ruby API client v4.0.1-alpha.0 (dry run)
      
      Artifact
       fastly-4.0.1.pre.alpha.0.gem (454KB)
      
      Generated on: Tue Dec 13 08:24:48 UTC 2022
      G-code: 8b4af0da, D-code: 237fa474
      Pre-release Tag: alpha
      ```

This CI relies on a rubygems.com scoped API key https://guides.rubygems.org/api-key-scopes/ with "publish rubygem" access to the `fastly` gem. This token is stored as a repository secret under the name `RUBYGEMS_PUBLISH_TOKEN`.
