### PR TITLE
Update rubygems on runner to get "gem exec"

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -97,6 +97,7 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+          rubygems: latest
 
       - name: Publish gem with trusted publishing
         uses: rubygems/release-gem@v1

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -25,8 +25,9 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.4"
           bundler-cache: true
+          rubygems: latest
 
       - name: Compute and validate release metadata
         id: meta
@@ -95,7 +96,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.4"
           bundler-cache: true
           rubygems: latest
 
@@ -122,8 +123,9 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.4"
           bundler-cache: true
+          rubygems: latest
 
       - name: Fetch published gem from RubyGems
         id: fetch


### PR DESCRIPTION
Evidently the `gem` command installed with Ruby 3.1 doesn't include `gem exec` which is used by publish-gem

We can get an updated `gem` command by setting rubygems:latest